### PR TITLE
update mvn docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "6464:7474"
 
   backend:
-    image: maven:3.5.0-jdk-8
+    image: maven:3.5.2-jdk-8
     working_dir: /www
     command: mvn spring-boot:run
     ports:


### PR DESCRIPTION
이전엔 잘 쓰던거라 왜 그런지 모르겠는데 다음과 같은 오류가 발생합니다.

```
backend_1     | /usr/bin/mvn: 1: /usr/bin/mvn: dirname: Exec format error
backend_1     | Error: Could not find or load main class org.codehaus.plexus.classworlds.launcher.Launcher
```

제 로컬 문제인지 모르겠는데 docker-compose가 이상한가 싶어서 `maven:3.5.0-jdk-8` 이미지에 들어가서 mvn을 실행해 보면 위와 비슷한 오류가 발생해서 3.5.2로 올렸습니다. 
제 로컬문제인지 아닌지 확실치도 않고 백엔드 쪽이라 PR로 올립니다.